### PR TITLE
Fix loading schematics with repeated palette entries

### DIFF
--- a/src/main/java/xyz/holocons/mc/litematicaprotocol/fabric/BlockStateFormatter.java
+++ b/src/main/java/xyz/holocons/mc/litematicaprotocol/fabric/BlockStateFormatter.java
@@ -1,0 +1,24 @@
+package xyz.holocons.mc.litematicaprotocol.fabric;
+
+import fi.dy.masa.litematica.schematic.container.LitematicaBlockStateContainer;
+import net.minecraft.block.BlockState;
+import net.minecraft.registry.Registries;
+
+import java.util.StringJoiner;
+
+public class BlockStateFormatter {
+
+    private final BlockState blockState;
+
+    public BlockStateFormatter(BlockState blockState) {
+        this.blockState = blockState != null ? blockState : LitematicaBlockStateContainer.AIR_BLOCK_STATE;
+    }
+
+    @Override
+    public String toString() {
+        final var propertyJoiner = new StringJoiner(",", "[", "]").setEmptyValue("");
+        blockState.getEntries().forEach((property, comparable) -> propertyJoiner
+            .add(property.getName() + '=' + String.valueOf(comparable).toLowerCase()));
+        return Registries.BLOCK.getId(blockState.getBlock()).toString() + propertyJoiner.toString();
+    }
+}

--- a/src/main/java/xyz/holocons/mc/litematicaprotocol/fabric/SpongePalette.java
+++ b/src/main/java/xyz/holocons/mc/litematicaprotocol/fabric/SpongePalette.java
@@ -1,0 +1,43 @@
+package xyz.holocons.mc.litematicaprotocol.fabric;
+
+import fi.dy.masa.litematica.schematic.container.ILitematicaBlockStatePalette;
+import net.minecraft.block.BlockState;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Palettes in .litematic may have repeated entries, but in .schem all palettes must be unique
+ */
+public class SpongePalette {
+
+    List<String> uniqueIds = new ArrayList<>();
+
+    public SpongePalette(ILitematicaBlockStatePalette palette) {
+        for (int i = 0; i < palette.getPaletteSize(); i++) {
+            final var blockState = palette.getBlockState(i);
+            final var blockStateString = new BlockStateFormatter(blockState).toString();
+
+            if (uniqueIds.contains(blockStateString))
+                continue;
+
+            uniqueIds.add(blockStateString);
+        }
+    }
+
+    public int idFor(BlockState blockState) {
+        final var blockStateString = new BlockStateFormatter(blockState).toString();
+
+        return uniqueIds.indexOf(blockStateString);
+    }
+
+    @Nullable
+    public String getId(int i) {
+        return uniqueIds.get(i);
+    }
+
+    public int getPaletteSize() {
+        return uniqueIds.size();
+    }
+}


### PR DESCRIPTION
This may happen with .nbt files generated from MapartCraft when the supporting blocks use a same material from the rest of the schematic.