### PR TITLE
Add support for larger schematics, up to a reasonable limit

### DIFF
--- a/src/main/java/xyz/holocons/mc/litematicaprotocol/Constants.java
+++ b/src/main/java/xyz/holocons/mc/litematicaprotocol/Constants.java
@@ -5,6 +5,12 @@ public final class Constants {
     public static final String NAMESPACE = "litematicaprotocol";
     public static final String MAIN = "main";
     public static final String SPONGE_SCHEMATIC = "0";
+    public static final String SPONGE_SCHEMATIC_SPLIT = "1";
+
+    public static final int MAX_PAYLOAD_LENGTH = 32767;
+    public static final int MAX_TOTAL_PAYLOAD_LENGTH = 2 * (1 << 16);
+
+    public static final int PACKET_TICK_INTERVAL = 1;
 
     private Constants() {
     }

--- a/src/main/java/xyz/holocons/mc/litematicaprotocol/fabric/ITask.java
+++ b/src/main/java/xyz/holocons/mc/litematicaprotocol/fabric/ITask.java
@@ -1,0 +1,10 @@
+package xyz.holocons.mc.litematicaprotocol.fabric;
+
+public interface ITask {
+
+    int getTickOffset();
+
+    void setTickOffset(int offset);
+
+    void run();
+}

--- a/src/main/java/xyz/holocons/mc/litematicaprotocol/fabric/SendSchematicPacketTask.java
+++ b/src/main/java/xyz/holocons/mc/litematicaprotocol/fabric/SendSchematicPacketTask.java
@@ -1,0 +1,46 @@
+package xyz.holocons.mc.litematicaprotocol.fabric;
+
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.minecraft.network.PacketByteBuf;
+
+public class SendSchematicPacketTask implements ITask {
+    public int offset;
+    public PacketByteBuf byteBuf;
+
+    public SendSchematicPacketTask(PacketByteBuf byteBuf, int tickOffset) {
+        this.byteBuf = byteBuf;
+        this.offset = tickOffset;
+    }
+
+    @Override
+    public int getTickOffset() {
+        return offset;
+    }
+
+    @Override
+    public void setTickOffset(int offset) {
+        this.offset = offset;
+    }
+
+    @Override
+    public void run() {
+
+        /*
+        //DEBUG
+        try {
+            FileOutputStream outputStream = new FileOutputStream("schematic parts.hex", true);
+            byteBuf.markReaderIndex();
+            byteBuf.markWriterIndex();
+            byteBuf.skipBytes(2 + 1 + 8 + 8 + 4 + 4);
+            byteBuf.getBytes(byteBuf.readerIndex(), outputStream, byteBuf.readableBytes());
+            byteBuf.resetReaderIndex();
+            byteBuf.resetWriterIndex();
+            outputStream.close();
+        } catch (Exception ignored) {
+        }
+        //DEBUG
+        */
+
+        ClientPlayNetworking.send(LitematicaProtocolMod.CHANNEL_MAIN, byteBuf);
+    }
+}

--- a/src/main/java/xyz/holocons/mc/litematicaprotocol/fabric/TaskManager.java
+++ b/src/main/java/xyz/holocons/mc/litematicaprotocol/fabric/TaskManager.java
@@ -1,0 +1,52 @@
+package xyz.holocons.mc.litematicaprotocol.fabric;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TaskManager {
+    private static final TaskManager INSTANCE = new TaskManager();
+
+    private final List<ITask> taskList = new ArrayList<>();
+
+    public static TaskManager getInstance() {
+        return INSTANCE;
+    }
+
+    public void register(ITask task)  {
+        this.taskList.add(task);
+    }
+
+    public void tick() {
+        List<ITask> removalList = null;
+
+        for (var task : taskList) {
+            int offset = task.getTickOffset();
+            if (offset > 0) {
+                task.setTickOffset(offset - 1);
+                continue;
+            }
+
+            task.run();
+
+            if (removalList == null)
+                removalList = new ArrayList<>();
+
+            removalList.add(task);
+        }
+
+        if (removalList != null)
+            for (var removal : removalList)
+                taskList.remove(removal);
+    }
+
+    public int getTopTickOffset() {
+        int topOffset = 0;
+        for (var task : taskList) {
+            int offset = task.getTickOffset();
+            if (offset > topOffset) {
+                topOffset = offset;
+            }
+        }
+        return topOffset;
+    }
+}

--- a/src/main/java/xyz/holocons/mc/litematicaprotocol/fabric/mixin/MinecraftClientMixin.java
+++ b/src/main/java/xyz/holocons/mc/litematicaprotocol/fabric/mixin/MinecraftClientMixin.java
@@ -1,0 +1,17 @@
+package xyz.holocons.mc.litematicaprotocol.fabric.mixin;
+
+import net.minecraft.client.MinecraftClient;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import xyz.holocons.mc.litematicaprotocol.fabric.TaskManager;
+
+@Mixin(MinecraftClient.class)
+public class MinecraftClientMixin {
+    @Inject(method = "tick()V", at = @At("RETURN"))
+    private void onPostKeyboardInput(CallbackInfo ci)
+    {
+        TaskManager.getInstance().tick();
+    }
+}

--- a/src/main/java/xyz/holocons/mc/litematicaprotocol/paper/SpongeSchematicData.java
+++ b/src/main/java/xyz/holocons/mc/litematicaprotocol/paper/SpongeSchematicData.java
@@ -1,0 +1,11 @@
+package xyz.holocons.mc.litematicaprotocol.paper;
+
+import java.io.InputStream;
+import java.util.UUID;
+
+public class SpongeSchematicData {
+    public UUID uuid;
+    public InputStream inputStream;
+    public int currentSplit;
+    public int totalSplits;
+}

--- a/src/main/java/xyz/holocons/mc/litematicaprotocol/paper/SpongeSchematicSplit.java
+++ b/src/main/java/xyz/holocons/mc/litematicaprotocol/paper/SpongeSchematicSplit.java
@@ -1,0 +1,105 @@
+package xyz.holocons.mc.litematicaprotocol.paper;
+
+import com.sk89q.worldedit.extent.clipboard.Clipboard;
+import com.sk89q.worldedit.extent.clipboard.io.BuiltInClipboardFormat;
+import org.bukkit.entity.Player;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.SequenceInputStream;
+import java.util.HashMap;
+import java.util.UUID;
+
+public class SpongeSchematicSplit {
+    private static final SpongeSchematicSplit INSTANCE = new SpongeSchematicSplit();
+
+    private final HashMap<Player, SpongeSchematicData> splits = new HashMap<>();
+
+    public static SpongeSchematicSplit getInstance() {
+        return INSTANCE;
+    }
+    public Clipboard push(DataInputStream in, Player player, UUID uuid, int currentSplit, int totalSplits) throws IOException {
+        SpongeSchematicData data = splits.get(player);
+        if (data == null) {
+            if (currentSplit != 1) {
+                throw new IOException(String.format("Out of order: %d / %d. Expected 1 / any.", currentSplit, totalSplits));
+            }
+
+            //First part, makes sense
+            if (totalSplits == 1) {
+                //Finished. Compatibility in case there is really only one part.
+                return BuiltInClipboardFormat.SPONGE_SCHEMATIC.getReader(in).read();
+            }
+
+            //Populate hashMap initially
+            data = new SpongeSchematicData();
+            data.uuid = uuid;
+            data.inputStream = new ByteArrayInputStream(in.readAllBytes());
+            data.currentSplit = currentSplit;
+            data.totalSplits = totalSplits;
+            splits.put(player, data);
+            return null;
+        }
+
+        if (data.uuid.equals(uuid) && data.currentSplit + 1 == currentSplit && data.totalSplits == totalSplits) {
+            //Next part, makes sense
+
+            final var currentReader = new SequenceInputStream(data.inputStream, new ByteArrayInputStream(in.readAllBytes()));
+
+            if (currentSplit == totalSplits) {
+                //Finished.
+
+                /*
+                //DEBUG - will break code
+                try {
+                    FileOutputStream outputStream = new FileOutputStream("schematic parts.litematic", false);
+                    currentReader.transferTo(outputStream);
+                } catch (Exception ignored) {
+                }
+                //DEBUG
+                 */
+
+                splits.remove(player);
+
+                return BuiltInClipboardFormat.SPONGE_SCHEMATIC.getReader(currentReader).read();
+            }
+
+            //Concatenate on hashMap
+            data.inputStream = currentReader;
+            data.currentSplit = currentSplit;
+            return null;
+        }
+
+        //To reach here, something uncommon happened
+
+        //UUID changed?
+        if (!data.uuid.equals(uuid)) {
+            //Change of UUID - latency too high and player pasted a different schematic or just spam?
+            if (data.currentSplit != 1) {
+                throw new IOException(String.format("Unexpected %d / %d (%s). Expected %d / %d (%s).",
+                    currentSplit, totalSplits, uuid,
+                    data.currentSplit + 1, data.totalSplits, data.uuid));
+            }
+
+            //First part
+            if (totalSplits == 1) {
+                //Finished. Compatibility in case there is really only one part.
+
+                splits.remove(player);
+
+                return BuiltInClipboardFormat.SPONGE_SCHEMATIC.getReader(in).read();
+            }
+            //Replace previous data
+            data.uuid = uuid;
+            data.inputStream.close();
+            data.inputStream = new ByteArrayInputStream(in.readAllBytes());
+            data.currentSplit = currentSplit;
+            data.totalSplits = totalSplits;
+            return null;
+        }
+
+        throw new IOException(String.format("Out of order: %d / %d. Expected %d / %d.",
+            currentSplit, totalSplits, data.currentSplit + 1, data.totalSplits));
+    }
+}

--- a/src/main/resources/litematicaprotocol.mixins.json
+++ b/src/main/resources/litematicaprotocol.mixins.json
@@ -4,6 +4,7 @@
   "package": "xyz.holocons.mc.litematicaprotocol.fabric.mixin",
   "compatibilityLevel": "JAVA_17",
   "client": [
+    "MinecraftClientMixin",
     "SchematicPlacementManagerMixin"
   ],
   "injectors": {


### PR DESCRIPTION
- Max limit of 32767 was increased to a bit more than 131072 (headers of each split packets aren't counted). This limit (MAX_TOTAL_PAYLOAD_LENGTH) could be decreased further, since a 2x2 3D valley map art schematic already lags a bit during //paste.
- Split packets are sent tick after tick (if everything were to be sent immediately, Paper would kick the player). Might need fiddling with the constant PACKET_TICK_INTERVAL using high latency networks.
- Split packets have UUID and current/last counter controls, in case the player spams clipboarding large schematics, so splits don't get garbled.