### PR TITLE
Port to 1.21.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 17 ]
+        java: [ 21 ]
       fail-fast: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -21,7 +21,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build --stacktrace
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.event.repository.name }}-${{ github.sha }}
           path: build/libs/*.jar

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 base {
@@ -47,7 +47,7 @@ processResources {
 
 tasks.withType(JavaCompile).configureEach {
     it.options.encoding = "UTF-8"
-    it.options.release = 17
+    it.options.release = 21
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,15 +8,15 @@ description=Support for litematica on client to worldedit on server communicatio
 modVersion=1.0.0
 
 # Fabric
-minecraftVersion=1.20.4
-loaderVersion=0.14.23
-yarnMappings=1.20.4+build.3
+minecraftVersion=1.21.1
+loaderVersion=0.16.0
+yarnMappings=1.21.1+build.3
 
 # Paper
-apiVersion=1.20
+apiVersion=1.21.1
 
 # Dependencies
-fabricVersion=0.97.1+1.20.4
-paperVersion=1.20.4-R0.1-SNAPSHOT
-litematicaFileId=5393557
-worldeditVersion=7.2.18
+fabricVersion=0.103.0+1.21.1
+paperVersion=1.21.1-R0.1-SNAPSHOT
+litematicaFileId=5647809
+worldeditVersion=7.3.6

--- a/src/main/java/xyz/holocons/mc/litematicaprotocol/fabric/ClientSchematicPayload.java
+++ b/src/main/java/xyz/holocons/mc/litematicaprotocol/fabric/ClientSchematicPayload.java
@@ -1,0 +1,22 @@
+package xyz.holocons.mc.litematicaprotocol.fabric;
+
+import io.netty.buffer.ByteBuf;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+import net.minecraft.util.Identifier;
+import xyz.holocons.mc.litematicaprotocol.Constants;
+
+public record ClientSchematicPayload(ByteBuf buf) implements CustomPayload {
+    public static final CustomPayload.Id<ClientSchematicPayload> PACKET_ID = new CustomPayload.Id<>(Identifier.of(Constants.NAMESPACE, Constants.MAIN));
+    public static final PacketCodec<RegistryByteBuf, ClientSchematicPayload> PACKET_CODEC = PacketCodec.of(ClientSchematicPayload::write, ClientSchematicPayload::new);
+
+    @Override
+    public Id<? extends CustomPayload> getId() {
+        return PACKET_ID;
+    }
+
+    public void write(RegistryByteBuf buf) {
+        buf.writeBytes(this.buf);
+    }
+}

--- a/src/main/java/xyz/holocons/mc/litematicaprotocol/fabric/LitematicaProtocolMod.java
+++ b/src/main/java/xyz/holocons/mc/litematicaprotocol/fabric/LitematicaProtocolMod.java
@@ -6,6 +6,7 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.networking.v1.C2SPlayChannelEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.PacketSender;
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.util.Identifier;
@@ -13,7 +14,7 @@ import xyz.holocons.mc.litematicaprotocol.Constants;
 
 public final class LitematicaProtocolMod implements ClientModInitializer {
 
-    public static final Identifier CHANNEL_MAIN = new Identifier(Constants.NAMESPACE, Constants.MAIN);
+    public static final Identifier CHANNEL_MAIN = Identifier.of(Constants.NAMESPACE, Constants.MAIN);
 
     private static boolean isProtocolAvailable = false;
 
@@ -21,6 +22,7 @@ public final class LitematicaProtocolMod implements ClientModInitializer {
     public void onInitializeClient() {
         ClientPlayConnectionEvents.JOIN.register(this::onPlayReady);
         C2SPlayChannelEvents.REGISTER.register(this::onChannelRegister);
+        PayloadTypeRegistry.playC2S().register(ClientSchematicPayload.PACKET_ID, ClientSchematicPayload.PACKET_CODEC);
     }
 
     public static boolean isProtocolAvailable() {

--- a/src/main/java/xyz/holocons/mc/litematicaprotocol/fabric/TaskSendSchematic.java
+++ b/src/main/java/xyz/holocons/mc/litematicaprotocol/fabric/TaskSendSchematic.java
@@ -43,7 +43,7 @@ public class TaskSendSchematic extends TaskBase {
             out.writeInt(data.readableBytes());
             data.readBytes(out, Math.min(data.readableBytes(), MAX_PAYLOAD_SIZE - out.writtenBytes()));
         }
-        ClientPlayNetworking.send(LitematicaProtocolMod.CHANNEL_MAIN, message);
+        ClientPlayNetworking.send(new ClientSchematicPayload(message));
         return data.readableBytes() == 0;
     }
 }

--- a/src/main/java/xyz/holocons/mc/litematicaprotocol/paper/ServerSchematic.java
+++ b/src/main/java/xyz/holocons/mc/litematicaprotocol/paper/ServerSchematic.java
@@ -62,7 +62,7 @@ public class ServerSchematic {
     private static Clipboard createClipboard(final ServerSchematic schematic) throws IOException {
         final Clipboard clipboard;
         try (final var in = new ByteArrayInputStream(schematic.data)) {
-            clipboard = BuiltInClipboardFormat.SPONGE_SCHEMATIC.getReader(in).read();
+            clipboard = BuiltInClipboardFormat.SPONGE_V2_SCHEMATIC.getReader(in).read();
         }
         return clipboard;
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,8 +26,8 @@
   "depends": {
     "fabricloader": ">=${loaderVersion}",
     "fabric-api": "*",
-    "minecraft": "1.20.4",
-    "java": ">=17",
+    "minecraft": ">=1.21.1",
+    "java": ">=21",
     "litematica": "*"
   }
 }

--- a/src/main/resources/litematicaprotocol.mixins.json
+++ b/src/main/resources/litematicaprotocol.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "xyz.holocons.mc.litematicaprotocol.fabric.mixin",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "client": [
     "SchematicPlacementManagerMixin"
   ],


### PR DESCRIPTION
ClientPlayNetworking.send now requires a CustomPayload and registration through PayloadTypeRegistry.playC2S().register.

More info:
https://fabricmc.net/2024/04/19/1205.html#networking

Note: it was attempted to use PacketCodecs.NBT_COMPOUND, but everything that extends NbtSchematicElement would need to at least implement accept() properly
